### PR TITLE
Test IntegerWrapperBodyMarshaller with no-arg constructor

### DIFF
--- a/sexp/src/test/java/com/novoda/sexp/marshaller/IntegerWrapperBodyMarshallerShould.java
+++ b/sexp/src/test/java/com/novoda/sexp/marshaller/IntegerWrapperBodyMarshallerShould.java
@@ -29,6 +29,13 @@ public class IntegerWrapperBodyMarshallerShould {
         cut.marshall("");
     }
 
+    @Test(expected = RuntimeException.class)
+    public void failForClassesWithNoArgConstructor() throws Exception {
+        IntegerWrapperBodyMarshaller<NoArgWrapperClass> cut = integerWrapperBodyMarshaller(NoArgWrapperClass.class);
+
+        cut.marshall("");
+    }
+
     private <T> IntegerWrapperBodyMarshaller<T> integerWrapperBodyMarshaller(Class<T> clazz) {
         return new IntegerWrapperBodyMarshaller<T>(clazz);
     }
@@ -63,6 +70,11 @@ public class IntegerWrapperBodyMarshallerShould {
 
     private static class TwoArgWrapperClass {
         private TwoArgWrapperClass(int one, int two) {
+        }
+    }
+
+    private static class NoArgWrapperClass {
+        public NoArgWrapperClass() {
         }
     }
 }


### PR DESCRIPTION
Add test to make sure IntegerWrapperBodyMarshaller fails for classes with only a no-argument constructor
