### PR TITLE
Applying the new novoda bintray release plugin

### DIFF
--- a/sexp/build.gradle
+++ b/sexp/build.gradle
@@ -35,6 +35,7 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'sexp'
+    uploadName = 'SimpleEasyXmlParser'
     version = project.version
     description = 'Oh hi, this is a nice description for a project right?'
     website = 'https://github.com/novoda/SimpleEasyXmlParser'


### PR DESCRIPTION
Removes the maven and signing plugins in favour of the new novoda release plugin.
- We lose the ability to release snapshots but we've agreed that we will no longer be using them.
