### PR TITLE
Supporting blocking (return type) xml parsing

### DIFF
--- a/demoAndroid/src/main/AndroidManifest.xml
+++ b/demoAndroid/src/main/AndroidManifest.xml
@@ -1,46 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.novoda.demoandroid">
+  package="com.novoda.demoandroid">
 
-    <application
-        android:allowBackup="true"
-        android:icon="@drawable/ic_launcher"
-        android:label="@string/app_name"
-        android:theme="@android:style/Theme.WithActionBar" >
-        <activity
-            android:name="com.novoda.demoandroid.MenuActivity"
-            android:label="@string/title_activity_menu" >
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
+  <application
+    android:allowBackup="true"
+    android:icon="@drawable/ic_launcher"
+    android:label="@string/app_name"
+    android:theme="@android:style/Theme.WithActionBar">
+    <activity
+      android:name="com.novoda.demoandroid.MenuActivity"
+      android:label="@string/title_activity_menu">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
 
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
-        <activity
-            android:name="com.novoda.demoandroid.onetag.OneTagActivity"
-            android:label="@string/title_activity_one_tag" 
-            android:parentActivityName="com.novoda.demoandroid.MenuActivity">
-        </activity>
-        <activity
-            android:name="com.novoda.demoandroid.simple.SimpleExampleActivity"
-            android:label="@string/title_activity_simple_example" 
-            android:parentActivityName="com.novoda.demoandroid.MenuActivity">
-        </activity>
-        <activity
-            android:name="com.novoda.demoandroid.team.TeamExampleActivity"
-            android:label="@string/title_activity_team_example" 
-            android:parentActivityName="com.novoda.demoandroid.MenuActivity">
-        </activity>
-        <activity
-            android:name="com.novoda.demoandroid.podcast.PodcastExampleActivity"
-            android:label="@string/title_activity_podcast" 
-            android:parentActivityName="com.novoda.demoandroid.MenuActivity">
-        </activity>
-        <activity
-            android:name="com.novoda.demoandroid.SecondLevelBaseActivity"
-            android:label="@string/title_activity_base" 
-            android:parentActivityName="com.novoda.demoandroid.MenuActivity">
-        </activity>
-    </application>
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+
+    <activity
+      android:name="com.novoda.demoandroid.onetag.OneTagActivity"
+      android:label="@string/title_activity_one_tag"
+      android:parentActivityName="com.novoda.demoandroid.MenuActivity" />
+    <activity
+      android:name=".returnvalue.ReturnValueActivity"
+      android:label="@string/title_activity_return_value"
+      android:parentActivityName="com.novoda.demoandroid.MenuActivity" />
+    <activity
+      android:name="com.novoda.demoandroid.simple.SimpleExampleActivity"
+      android:label="@string/title_activity_simple_example"
+      android:parentActivityName="com.novoda.demoandroid.MenuActivity" />
+    <activity
+      android:name="com.novoda.demoandroid.team.TeamExampleActivity"
+      android:label="@string/title_activity_team_example"
+      android:parentActivityName="com.novoda.demoandroid.MenuActivity" />
+    <activity
+      android:name="com.novoda.demoandroid.podcast.PodcastExampleActivity"
+      android:label="@string/title_activity_podcast"
+      android:parentActivityName="com.novoda.demoandroid.MenuActivity" />
+    <activity
+      android:name="com.novoda.demoandroid.SecondLevelBaseActivity"
+      android:label="@string/title_activity_base"
+      android:parentActivityName="com.novoda.demoandroid.MenuActivity" />
+  </application>
 
 </manifest>

--- a/demoAndroid/src/main/java/com/novoda/demoandroid/MenuActivity.java
+++ b/demoAndroid/src/main/java/com/novoda/demoandroid/MenuActivity.java
@@ -1,8 +1,5 @@
 package com.novoda.demoandroid;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -13,69 +10,75 @@ import android.widget.AdapterView.OnItemClickListener;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 
+import com.novoda.demoandroid.returnvalue.ReturnValueActivity;
 import com.novoda.demoandroid.onetag.OneTagActivity;
 import com.novoda.demoandroid.podcast.PodcastExampleActivity;
 import com.novoda.demoandroid.simple.SimpleExampleActivity;
 import com.novoda.demoandroid.team.TeamExampleActivity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class MenuActivity extends Activity {
-	private static final int DIVIDER_HEIGHT = 2;
-	private ListView menu;
-	private Context context;
+    private static final int DIVIDER_HEIGHT = 2;
 
-	@Override
-	protected void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-		setContentView(R.layout.activity_menu);
-		
-		context = this;
-		menu = (ListView) findViewById(R.id.lv_menu);
-		List<NavigationItem> items = populateNavigationMenu();
-		ArrayAdapter<NavigationItem> adapter;
-		adapter = new ArrayAdapter<NavigationItem>(this, android.R.layout.simple_list_item_1, android.R.id.text1, items);
+    private Context context;
 
-		menu.setAdapter(adapter);
-		menu.setDividerHeight(DIVIDER_HEIGHT);
-		menu.setOnItemClickListener(new OnItemClickListener() {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_menu);
 
-			@Override
-			public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-				NavigationItem current = (NavigationItem) parent.getItemAtPosition(position);
-				Intent intent = new Intent(context, current.getType());
-				startActivity(intent);
-			}
-		});
-	}
-	
-	private List<NavigationItem> populateNavigationMenu (){
-		List<NavigationItem> items = new ArrayList<NavigationItem>();
-		items.add(new NavigationItem(OneTagActivity.class, getResources().getString(R.string.title_activity_one_tag)));
-		items.add(new NavigationItem(SimpleExampleActivity.class, getResources().getString(R.string.title_activity_simple_example)));
-		items.add(new NavigationItem(PodcastExampleActivity.class, getResources().getString(R.string.title_activity_podcast)));
-		items.add(new NavigationItem(TeamExampleActivity.class, getResources().getString(R.string.title_activity_team_example)));
-		return items;
-	}
+        context = this;
+        ListView menu = (ListView) findViewById(R.id.lv_menu);
+        List<NavigationItem> items = populateNavigationMenu();
+        ArrayAdapter<NavigationItem> adapter;
+        adapter = new ArrayAdapter<NavigationItem>(this, android.R.layout.simple_list_item_1, android.R.id.text1, items);
 
-	public static class NavigationItem {
-		Class<? extends Activity> type;
-		String title;
+        menu.setAdapter(adapter);
+        menu.setDividerHeight(DIVIDER_HEIGHT);
+        menu.setOnItemClickListener(
+                new OnItemClickListener() {
+                    @Override
+                    public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                        NavigationItem current = (NavigationItem) parent.getItemAtPosition(position);
+                        Intent intent = new Intent(context, current.getType());
+                        startActivity(intent);
+                    }
+                }
+        );
+    }
 
-		public Class<? extends Activity> getType() {
-			return type;
-		}
+    private List<NavigationItem> populateNavigationMenu() {
+        List<NavigationItem> items = new ArrayList<NavigationItem>();
+        items.add(new NavigationItem(OneTagActivity.class, getResources().getString(R.string.title_activity_one_tag)));
+        items.add(new NavigationItem(ReturnValueActivity.class, getResources().getString(R.string.title_activity_return_value)));
+        items.add(new NavigationItem(SimpleExampleActivity.class, getResources().getString(R.string.title_activity_simple_example)));
+        items.add(new NavigationItem(PodcastExampleActivity.class, getResources().getString(R.string.title_activity_podcast)));
+        items.add(new NavigationItem(TeamExampleActivity.class, getResources().getString(R.string.title_activity_team_example)));
+        return items;
+    }
 
-		public String getTitle() {
-			return title;
-		}
+    public static class NavigationItem {
+        Class<? extends Activity> type;
+        String title;
 
-		public NavigationItem(Class<? extends Activity> type, String title) {
-			this.type = type;
-			this.title = title;
-		}
+        public Class<? extends Activity> getType() {
+            return type;
+        }
 
-		@Override
-		public String toString() {
-			return title;
-		}
-	}
+        public String getTitle() {
+            return title;
+        }
+
+        public NavigationItem(Class<? extends Activity> type, String title) {
+            this.type = type;
+            this.title = title;
+        }
+
+        @Override
+        public String toString() {
+            return title;
+        }
+    }
 }

--- a/demoAndroid/src/main/java/com/novoda/demoandroid/returnvalue/ReturnValueActivity.java
+++ b/demoAndroid/src/main/java/com/novoda/demoandroid/returnvalue/ReturnValueActivity.java
@@ -41,7 +41,7 @@ public class ReturnValueActivity extends SecondLevelBaseActivity {
         new ParsingTask(XML, instigator).execute();
     }
 
-    public static class SimpleInstigator extends ElementFinderInstigator<String> {
+    private static class SimpleInstigator extends ElementFinderInstigator<String> {
 
         public SimpleInstigator(ElementFinder<String> elementFinder, String elementTag) {
             super(elementFinder, elementTag);
@@ -53,7 +53,7 @@ public class ReturnValueActivity extends SecondLevelBaseActivity {
         }
     }
 
-    public class ParsingTask extends AsyncTask<Void, Void, String> {
+    private class ParsingTask extends AsyncTask<Void, Void, String> {
         private String xmlToParse;
         private SimpleInstigator instigator;
 

--- a/demoAndroid/src/main/java/com/novoda/demoandroid/returnvalue/ReturnValueActivity.java
+++ b/demoAndroid/src/main/java/com/novoda/demoandroid/returnvalue/ReturnValueActivity.java
@@ -1,0 +1,79 @@
+package com.novoda.demoandroid.returnvalue;
+
+import android.annotation.SuppressLint;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import com.novoda.demoandroid.R;
+import com.novoda.demoandroid.SecondLevelBaseActivity;
+import com.novoda.sexp.ElementFinderInstigator;
+import com.novoda.sexp.RootTag;
+import com.novoda.sexp.SimpleEasyXmlParser;
+import com.novoda.sexp.finder.ElementFinder;
+import com.novoda.sexp.finder.ElementFinderFactory;
+
+public class ReturnValueActivity extends SecondLevelBaseActivity {
+    // language=XML
+    private static final String XML = "<novoda>"
+            + "<favouriteColour>Blue</favouriteColour>" + "</novoda>";
+
+    private TextView parsingResult;
+    private ProgressBar progressBar;
+    private LinearLayout container;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_result_parsing);
+
+        parsingResult = (TextView) findViewById(R.id.tv_result);
+        progressBar = (ProgressBar) findViewById(R.id.pb_oneTag);
+        container = (LinearLayout) findViewById(R.id.ll_oneTag);
+
+        ElementFinderFactory factory = SimpleEasyXmlParser.getElementFinderFactory();
+        ElementFinder<String> elementFinder = factory.getStringFinder();
+        SimpleInstigator instigator = new SimpleInstigator(elementFinder, "favouriteColour");
+
+        new ParsingTask(XML, instigator).execute();
+    }
+
+    public static class SimpleInstigator extends ElementFinderInstigator<String> {
+
+        public SimpleInstigator(ElementFinder<String> elementFinder, String elementTag) {
+            super(elementFinder, elementTag);
+        }
+
+        @Override
+        public RootTag getRootTag() {
+            return RootTag.create("novoda");
+        }
+    }
+
+    public class ParsingTask extends AsyncTask<Void, Void, String> {
+        private String xmlToParse;
+        private SimpleInstigator instigator;
+
+        public ParsingTask(String xml, SimpleInstigator anInstigator) {
+            xmlToParse = xml;
+            instigator = anInstigator;
+        }
+
+        @Override
+        protected String doInBackground(Void... params) {
+            return SimpleEasyXmlParser.parse(xmlToParse, instigator);
+        }
+
+        @SuppressLint("SetTextI18n") // Not in demo scope
+        @Override
+        protected void onPostExecute(String result) {
+            parsingResult.setText("Got " + result + " as a return value (not using a callback).");
+            container.setVisibility(View.VISIBLE);
+            progressBar.setVisibility(View.GONE);
+        }
+    }
+
+}

--- a/demoAndroid/src/main/res/values/strings.xml
+++ b/demoAndroid/src/main/res/values/strings.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="app_name">demoAndroid</string>
+  <string name="app_name">demoAndroid</string>
 
-    <string name="title_activity_menu">Menu</string>
-    <string name="title_activity_one_tag">One Tag Example</string>
-    <string name="title_activity_simple_example">Simple Example</string>
-    <string name="title_activity_team_example">Team Example</string>
-    <string name="title_activity_podcast">Podcast Example</string>
-    <string name="title_activity_base">BaseActivity</string>
-    
-    <string name="parsing_result">Parsing result :</string>
-    
+  <string name="title_activity_menu">Menu</string>
+  <string name="title_activity_return_value">Return Value Example</string>
+  <string name="title_activity_one_tag">One Tag Example</string>
+  <string name="title_activity_simple_example">Simple Example</string>
+  <string name="title_activity_team_example">Team Example</string>
+  <string name="title_activity_podcast">Podcast Example</string>
+  <string name="title_activity_base">BaseActivity</string>
+
+  <string name="parsing_result">Parsing result :</string>
+
 </resources>

--- a/sexp/src/main/java/com/novoda/sexp/ElementFinderInstigator.java
+++ b/sexp/src/main/java/com/novoda/sexp/ElementFinderInstigator.java
@@ -1,0 +1,29 @@
+package com.novoda.sexp;
+
+import com.novoda.sax.RootElement;
+import com.novoda.sexp.finder.ElementFinder;
+
+public abstract class ElementFinderInstigator<R> implements Instigator {
+
+    private final ElementFinder<R> elementFinder;
+    private final String elementTag;
+
+    public ElementFinderInstigator(ElementFinder<R> elementFinder, String elementTag) {
+        this.elementFinder = elementFinder;
+        this.elementTag = elementTag;
+    }
+
+    @Override
+    public void create(RootElement element) {
+        elementFinder.find(element, elementTag);
+    }
+
+    @Override
+    public void end() {
+        // no callback on completion
+    }
+
+    public R getResultOrThrow() {
+        return elementFinder.getResultOrThrow();
+    }
+}

--- a/sexp/src/main/java/com/novoda/sexp/ElementFinderInstigator.java
+++ b/sexp/src/main/java/com/novoda/sexp/ElementFinderInstigator.java
@@ -3,6 +3,12 @@ package com.novoda.sexp;
 import com.novoda.sax.RootElement;
 import com.novoda.sexp.finder.ElementFinder;
 
+/**
+ * This instigator can be used when you want to return your parsed object synchronously
+ * from the element finder. A good example being {@link SimpleEasyXmlParser#parse(String, ElementFinderInstigator)}
+ *
+ * @param <R> the type of object you expect as a result of xml parsing
+ */
 public abstract class ElementFinderInstigator<R> implements Instigator {
 
     private final ElementFinder<R> elementFinder;
@@ -23,6 +29,9 @@ public abstract class ElementFinderInstigator<R> implements Instigator {
         // no callback on completion
     }
 
+    /**
+     * @return the object you expected to be parsed from your dependent {@link ElementFinder<R>}
+     */
     public R getResultOrThrow() {
         return elementFinder.getResultOrThrow();
     }

--- a/sexp/src/main/java/com/novoda/sexp/SimpleEasyXmlParser.java
+++ b/sexp/src/main/java/com/novoda/sexp/SimpleEasyXmlParser.java
@@ -23,6 +23,10 @@ public class SimpleEasyXmlParser {
         parse(new ByteArrayInputStream(xml.getBytes()), instigator, getDefaultSEXPXMLReader());
     }
 
+    public static void parse(InputStream xml, Instigator instigator) {
+        parse(xml, instigator, getDefaultSEXPXMLReader());
+    }
+
     public static void parse(String xml, Instigator instigator, XMLReader xmlReader) {
         parse(new ByteArrayInputStream(xml.getBytes()), instigator, xmlReader);
     }

--- a/sexp/src/main/java/com/novoda/sexp/SimpleEasyXmlParser.java
+++ b/sexp/src/main/java/com/novoda/sexp/SimpleEasyXmlParser.java
@@ -12,26 +12,54 @@ import org.xml.sax.XMLReader;
 
 public class SimpleEasyXmlParser {
 
+    /**
+     * @return an {@link ElementFinderFactory} this Factory is how you select which XML elements to parse as what java types
+     * see it's javadoc for more
+     */
     public static ElementFinderFactory getElementFinderFactory() {
         return new ElementFinderFactory();
     }
 
+    /**
+     * @param xml        the xml to parse
+     * @param encoding   the encoding of your xml
+     * @param instigator your fully created parser of the xml
+     * @throws UnsupportedEncodingException if the encoding you passed isn't suppored
+     */
     public static void parse(String xml, String encoding, Instigator instigator) throws UnsupportedEncodingException {
         parse(new ByteArrayInputStream(xml.getBytes(encoding)), instigator, getDefaultSEXPXMLReader());
     }
 
+    /**
+     * @param xml        the xml to parse
+     * @param instigator your fully created parser of the xml
+     */
     public static void parse(String xml, Instigator instigator) {
         parse(new ByteArrayInputStream(xml.getBytes()), instigator, getDefaultSEXPXMLReader());
     }
 
+    /**
+     * @param xml        the xml to parse
+     * @param instigator your fully created parser of the xml
+     */
     public static void parse(InputStream xml, Instigator instigator) {
         parse(xml, instigator, getDefaultSEXPXMLReader());
     }
 
+    /**
+     * @param xml        the xml to parse
+     * @param instigator your fully created parser of the xml
+     * @param xmlReader  is the interface that an XML parser's SAX2 driver must implement , using this? _bad ass_ alert
+     */
     public static void parse(String xml, Instigator instigator, XMLReader xmlReader) {
         parse(new ByteArrayInputStream(xml.getBytes()), instigator, xmlReader);
     }
 
+    /**
+     * @param xml        the xml to parse
+     * @param instigator your fully created parser of the xml
+     * @param xmlReader  is the interface that an XML parser's SAX2 driver must implement , using this? _bad ass_ alert
+     */
     public static void parse(InputStream xml, Instigator instigator, XMLReader xmlReader) {
         RootTag rootTag = instigator.getRootTag();
         RootElement rootElement = new RootElement(rootTag.getNamespace(), rootTag.getTag());
@@ -42,22 +70,56 @@ public class SimpleEasyXmlParser {
         xmlParser.parse(xml, xmlReader);
     }
 
+    /**
+     * @param xml        the xml to parse
+     * @param encoding   the encoding of your xml
+     * @param instigator your fully created parser of the xml
+     * @param <T>        the expected type of your parsed XML
+     * @return your parsed XML as an object
+     * @throws UnsupportedEncodingException if the encoding you passed isn't suppored
+     */
     public static <T> T parse(String xml, String encoding, ElementFinderInstigator<T> instigator) throws UnsupportedEncodingException {
         return parse(new ByteArrayInputStream(xml.getBytes(encoding)), instigator, getDefaultSEXPXMLReader());
     }
 
+    /**
+     * @param xml        the xml to parse
+     * @param instigator your fully created parser of the xml
+     * @param <T>        the expected type of your parsed XML
+     * @return your parsed XML as an object
+     */
     public static <T> T parse(String xml, ElementFinderInstigator<T> instigator) {
         return parse(new ByteArrayInputStream(xml.getBytes()), instigator, getDefaultSEXPXMLReader());
     }
 
+    /**
+     * @param xml        the xml to parse
+     * @param instigator your fully created parser of the xml
+     * @param <T>        the expected type of your parsed XML
+     * @return your parsed XML as an object
+     */
     public static <T> T parse(InputStream xml, ElementFinderInstigator<T> instigator) {
         return parse(xml, instigator, getDefaultSEXPXMLReader());
     }
 
+    /**
+     * @param xml        the xml to parse
+     * @param instigator your fully created parser of the xml
+     * @param xmlReader  is the interface that an XML parser's SAX2 driver must implement , using this? _bad ass_ alert
+     * @param <T>        the expected type of your parsed XML
+     * @return your parsed XML as an object
+     */
     public static <T> T parse(String xml, ElementFinderInstigator<T> instigator, XMLReader xmlReader) {
         return parse(new ByteArrayInputStream(xml.getBytes()), instigator, xmlReader);
     }
 
+    /**
+     * @param xml        the xml to parse
+     * @param instigator your fully created parser of the xml
+     * @param xmlReader  is the interface that an XML parser's SAX2 driver must implement , using this? _bad ass_ alert
+     * @param <T>        the expected type of your parsed XML
+     * @return your parsed XML as an object
+     */
     public static <T> T parse(InputStream xml, final ElementFinderInstigator<T> instigator, XMLReader xmlReader) {
         final CountDownLatch latch = new CountDownLatch(1);
         Instigator latchedInstigator = new Instigator() {

--- a/sexp/src/main/java/com/novoda/sexp/SimpleEasyXmlParser.java
+++ b/sexp/src/main/java/com/novoda/sexp/SimpleEasyXmlParser.java
@@ -150,7 +150,7 @@ public class SimpleEasyXmlParser {
         try {
             latch.await();
         } catch (InterruptedException e) {
-            throw new RuntimeException();
+            throw new RuntimeException(e);
         }
 
         return instigator.getResultOrThrow();

--- a/sexp/src/main/java/com/novoda/sexp/SimpleEasyXmlParser.java
+++ b/sexp/src/main/java/com/novoda/sexp/SimpleEasyXmlParser.java
@@ -6,6 +6,7 @@ import com.novoda.sexp.finder.ElementFinderFactory;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.concurrent.CountDownLatch;
 
 import org.xml.sax.XMLReader;
 
@@ -39,6 +40,58 @@ public class SimpleEasyXmlParser {
         xmlReader.setContentHandler(rootElement.getContentHandler());
         XmlParser xmlParser = new XmlParser();
         xmlParser.parse(xml, xmlReader);
+    }
+
+    public static <T> T parse(String xml, String encoding, ElementFinderInstigator<T> instigator) throws UnsupportedEncodingException {
+        return parse(new ByteArrayInputStream(xml.getBytes(encoding)), instigator, getDefaultSEXPXMLReader());
+    }
+
+    public static <T> T parse(String xml, ElementFinderInstigator<T> instigator) {
+        return parse(new ByteArrayInputStream(xml.getBytes()), instigator, getDefaultSEXPXMLReader());
+    }
+
+    public static <T> T parse(InputStream xml, ElementFinderInstigator<T> instigator) {
+        return parse(xml, instigator, getDefaultSEXPXMLReader());
+    }
+
+    public static <T> T parse(String xml, ElementFinderInstigator<T> instigator, XMLReader xmlReader) {
+        return parse(new ByteArrayInputStream(xml.getBytes()), instigator, xmlReader);
+    }
+
+    public static <T> T parse(InputStream xml, final ElementFinderInstigator<T> instigator, XMLReader xmlReader) {
+        final CountDownLatch latch = new CountDownLatch(1);
+        Instigator latchedInstigator = new Instigator() {
+            @Override
+            public RootTag getRootTag() {
+                return instigator.getRootTag();
+            }
+
+            @Override
+            public void create(RootElement rootElement) {
+                instigator.create(rootElement);
+            }
+
+            @Override
+            public void end() {
+                latch.countDown();
+            }
+        };
+
+        RootTag rootTag = instigator.getRootTag();
+        RootElement rootElement = new RootElement(rootTag.getNamespace(), rootTag.getTag());
+        rootElement.setEndElementListener(latchedInstigator);
+        instigator.create(rootElement);
+        xmlReader.setContentHandler(rootElement.getContentHandler());
+        XmlParser xmlParser = new XmlParser();
+        xmlParser.parse(xml, xmlReader);
+
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException();
+        }
+
+        return instigator.getResultOrThrow();
     }
 
     private static XMLReader getDefaultSEXPXMLReader() {

--- a/sexp/src/main/java/com/novoda/sexp/finder/ElementFinder.java
+++ b/sexp/src/main/java/com/novoda/sexp/finder/ElementFinder.java
@@ -1,11 +1,25 @@
 package com.novoda.sexp.finder;
 
 import com.novoda.sax.Element;
-
 import com.novoda.sexp.parser.ParseWatcher;
 
 public interface ElementFinder<R> extends ParseWatcher<R> {
+
+    /**
+     * Find the given tag inside the given element
+     *
+     * @param from the XML element to search within
+     * @param tag  the XML tag to be searched for
+     */
     void find(Element from, String tag);
+
+    /**
+     * Find the given tag inside the given element
+     *
+     * @param from the XML element to search within
+     * @param uri  the XML namespace of the searched for tag
+     * @param tag  the XML tag to be searched for
+     */
     void find(Element from, String uri, String tag);
 
     @Override


### PR DESCRIPTION
Apparently sometimes people don't want to use callbacks :-)

And so this adds new `.parse(` methods to SEXP that allow for the XML parsed to be given as the return type of the parse method.

| Android Example |
| ----- |
|<img width="514" alt="screen shot 2015-12-16 at 20 34 50" src="https://cloud.githubusercontent.com/assets/655860/11853732/a5f14f2e-a437-11e5-9630-4cc37957e48b.png">| 

(you have to fight through the formatting changes in the example sorry!)