### PR TITLE
Adds `popResult` methods so that we can choose to not cache results

### DIFF
--- a/sexp/src/main/java/com/novoda/sexp/finder/BasicElementFinder.java
+++ b/sexp/src/main/java/com/novoda/sexp/finder/BasicElementFinder.java
@@ -41,9 +41,11 @@ public class BasicElementFinder<T> implements ElementFinder<T> {
 
     @Override
     public T popResult() {
-        T r = result;
-        result = null;
-        return r;
+        try {
+            return result;
+        } finally {
+            result = null;
+        }
     }
 
     @Override

--- a/sexp/src/main/java/com/novoda/sexp/finder/BasicElementFinder.java
+++ b/sexp/src/main/java/com/novoda/sexp/finder/BasicElementFinder.java
@@ -39,6 +39,19 @@ public class BasicElementFinder<T> implements ElementFinder<T> {
         return result;
     }
 
+    @Override
+    public T popResult() {
+        T r = result;
+        result = null;
+        return r;
+    }
+
+    @Override
+    public T popResultOrThrow() {
+        validateResult();
+        return popResult();
+    }
+
     private void validateResult() {
         if (result == null) {
             throw new ResultNotFoundException();

--- a/sexp/src/main/java/com/novoda/sexp/finder/ElementFinder.java
+++ b/sexp/src/main/java/com/novoda/sexp/finder/ElementFinder.java
@@ -25,7 +25,29 @@ public interface ElementFinder<R> extends ParseWatcher<R> {
     @Override
     void onParsed(R item);
 
+    /**
+     * @return the result of the parsing if the parsing was completed and tag was found
+     * or null if the tag was not found or parsing didn't complete.
+     */
     R getResult();
 
+    /**
+     * @return the result of the parsing if the parsing was completed and tag was found
+     * or throws an exception if the tag was not found or parsing didn't complete.
+     */
     R getResultOrThrow();
+
+    /**
+     * Same as {@link #getResult} but clears the result instead of keeping it.
+     * @return the result of the parsing if the parsing was completed and tag was found
+     * or null if the tag was not found or parsing didn't complete.
+     */
+    R popResult();
+
+    /**
+     * Same as {@link #getResultOrThrow} but clears the result instead of keeping it.
+     * @return the result of the parsing if the parsing was completed and tag was found
+     * or throws an exception if the tag was not found or parsing didn't complete.
+     */
+    R popResultOrThrow();
 }

--- a/sexp/src/main/java/com/novoda/sexp/finder/ListElementFinder.java
+++ b/sexp/src/main/java/com/novoda/sexp/finder/ListElementFinder.java
@@ -39,4 +39,14 @@ public class ListElementFinder<T> implements ElementFinder<T> {
         throw new UnsupportedOperationException("Has a listener to pass each item as parsed, so there is no result.");
     }
 
+    @Override
+    public T popResult() {
+        throw new UnsupportedOperationException("Has a listener to pass each item as parsed, so there is no result.");
+    }
+
+    @Override
+    public T popResultOrThrow() {
+        throw new UnsupportedOperationException("Has a listener to pass each item as parsed, so there is no result.");
+    }
+
 }

--- a/sexp/src/test/java/com/novoda/sexp/finder/BasicElementFinderShould.java
+++ b/sexp/src/test/java/com/novoda/sexp/finder/BasicElementFinderShould.java
@@ -56,7 +56,7 @@ public class BasicElementFinderShould {
     }
 
     @Test(expected = BasicElementFinder.ResultNotFoundException.class)
-    public void throw_exception_when_result_has_not_been_parsed_and_a_required_result_is_asked_for() throws Exception {
+    public void throw_exception_when_result_has_not_been_parsed_or_found_and_a_required_result_is_asked_for() throws Exception {
         elementCreator.getResultOrThrow();
     }
 
@@ -77,7 +77,7 @@ public class BasicElementFinderShould {
     }
 
     @Test(expected = BasicElementFinder.ResultNotFoundException.class)
-    public void throw_exception_when_result_has_not_been_parsed_and_a_result_is_popped() throws Exception {
+    public void throw_exception_when_result_has_not_been_parsed_or_found_and_a_result_is_popped() throws Exception {
         elementCreator.popResultOrThrow();
     }
 

--- a/sexp/src/test/java/com/novoda/sexp/finder/BasicElementFinderShould.java
+++ b/sexp/src/test/java/com/novoda/sexp/finder/BasicElementFinderShould.java
@@ -52,7 +52,7 @@ public class BasicElementFinderShould {
 
         elementCreator.onParsed(result);
 
-        assertThat(elementCreator.getResultOrThrow()).isEqualTo(result);
+        assertThat(elementCreator.getResult()).isEqualTo(result);
     }
 
     @Test(expected = BasicElementFinder.ResultNotFoundException.class)
@@ -65,6 +65,37 @@ public class BasicElementFinderShould {
         Object result = elementCreator.getResult();
 
         assertThat(result).isNull();
+    }
+
+    @Test
+    public void pop_a_result_when_parsing_finished() throws Exception {
+        String result = "result";
+
+        elementCreator.onParsed(result);
+
+        assertThat(elementCreator.popResult()).isEqualTo(result);
+    }
+
+    @Test(expected = BasicElementFinder.ResultNotFoundException.class)
+    public void throw_exception_when_result_has_not_been_parsed_and_a_result_is_popped() throws Exception {
+        elementCreator.popResultOrThrow();
+    }
+
+    @Test
+    public void allow_null_results_when_get_result_is_popped() throws Exception {
+        Object result = elementCreator.popResult();
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void not_cache_result_after_a_result_is_popped() throws Exception {
+        String result = "result";
+
+        elementCreator.onParsed(result);
+
+        assertThat(elementCreator.popResult()).isEqualTo(result);
+        assertThat(elementCreator.popResult()).isNull();
     }
 
 }

--- a/sexp/src/test/java/com/novoda/sexp/finder/BasicElementFinderShould.java
+++ b/sexp/src/test/java/com/novoda/sexp/finder/BasicElementFinderShould.java
@@ -70,10 +70,11 @@ public class BasicElementFinderShould {
     @Test
     public void pop_a_result_when_parsing_finished() throws Exception {
         String result = "result";
-
         elementCreator.onParsed(result);
 
-        assertThat(elementCreator.popResult()).isEqualTo(result);
+        Object actual = elementCreator.popResult();
+
+        assertThat(actual).isEqualTo(result);
     }
 
     @Test(expected = BasicElementFinder.ResultNotFoundException.class)
@@ -90,12 +91,12 @@ public class BasicElementFinderShould {
 
     @Test
     public void not_cache_result_after_a_result_is_popped() throws Exception {
-        String result = "result";
+        elementCreator.onParsed("ignore");
+        elementCreator.popResult();
 
-        elementCreator.onParsed(result);
+        Object actual = elementCreator.popResult();
 
-        assertThat(elementCreator.popResult()).isEqualTo(result);
-        assertThat(elementCreator.popResult()).isNull();
+        assertThat(actual).isNull();
     }
 
 }

--- a/sexp/src/test/java/com/novoda/sexp/finder/ListElementFinderShould.java
+++ b/sexp/src/test/java/com/novoda/sexp/finder/ListElementFinderShould.java
@@ -49,7 +49,22 @@ public class ListElementFinderShould {
 
     @Test(expected = UnsupportedOperationException.class)
     public void notSupportGetResult_asListCreatorWillCallbackAfterEveryListItemIsParsed() throws Exception {
+        elementCreator.getResult();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void notSupportGetResultOrThrow_asListCreatorWillCallbackAfterEveryListItemIsParsed() throws Exception {
         elementCreator.getResultOrThrow();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void notSupportPopResult_asListCreatorWillCallbackAfterEveryListItemIsParsed() throws Exception {
+        elementCreator.popResult();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void notSupportPopResultOrThrow_asListCreatorWillCallbackAfterEveryListItemIsParsed() throws Exception {
+        elementCreator.popResultOrThrow();
     }
 
 }


### PR DESCRIPTION
Adds `popResult` methods so that we can choose to not cache results
I've also added more jdoc and tests

This fixes the issue where if you're parsing a list of items (reusing the element finders) and one of them doesn't have a tag then you'd get the result from the previous one instead of null