### PR TITLE
Rename marshall to marshal

### DIFF
--- a/benchmark/src/main/java/com/novoda/sexp/medium/LinkAttributeMarshaller.java
+++ b/benchmark/src/main/java/com/novoda/sexp/medium/LinkAttributeMarshaller.java
@@ -4,7 +4,7 @@ import com.novoda.sexp.marshaller.AttributeMarshaller;
 
 public class LinkAttributeMarshaller implements AttributeMarshaller<SexpMediumXmlBenchmark.Link> {
         @Override
-        public SexpMediumXmlBenchmark.Link marshall(String... input) {
+        public SexpMediumXmlBenchmark.Link marshal(String... input) {
             SexpMediumXmlBenchmark.Link link = new SexpMediumXmlBenchmark.Link();
             link.href = input[0];
             link.rel = input[1];

--- a/demo/src/main/java/com/novoda/demo/advanced/podcast/parser/PodcastItemParser.java
+++ b/demo/src/main/java/com/novoda/demo/advanced/podcast/parser/PodcastItemParser.java
@@ -85,7 +85,7 @@ public class PodcastItemParser implements Parser<PodcastItem> {
 
     private static class ImageAttributeMarshaller implements AttributeMarshaller<Link> {
         @Override
-        public Link marshall(String... input) {
+        public Link marshal(String... input) {
             return new Link(input[0]);
         }
     }

--- a/sexp/src/main/java/com/novoda/sexp/marshaller/AttributeMarshaller.java
+++ b/sexp/src/main/java/com/novoda/sexp/marshaller/AttributeMarshaller.java
@@ -1,5 +1,5 @@
 package com.novoda.sexp.marshaller;
 
 public interface AttributeMarshaller<T> {
-    T marshall(String... input);
+    T marshal(String... input);
 }

--- a/sexp/src/main/java/com/novoda/sexp/marshaller/BodyMarshaller.java
+++ b/sexp/src/main/java/com/novoda/sexp/marshaller/BodyMarshaller.java
@@ -1,5 +1,5 @@
 package com.novoda.sexp.marshaller;
 
 public interface BodyMarshaller<T> {
-    T marshall(String input);
+    T marshal(String input);
 }

--- a/sexp/src/main/java/com/novoda/sexp/marshaller/BooleanBodyMarshaller.java
+++ b/sexp/src/main/java/com/novoda/sexp/marshaller/BooleanBodyMarshaller.java
@@ -2,7 +2,7 @@ package com.novoda.sexp.marshaller;
 
 public class BooleanBodyMarshaller implements BodyMarshaller<Boolean> {
     @Override
-    public Boolean marshall(String input) {
+    public Boolean marshal(String input) {
         if ("true".equalsIgnoreCase(input)) {
             return true;
         } else if ("false".equalsIgnoreCase(input)) {

--- a/sexp/src/main/java/com/novoda/sexp/marshaller/IntegerBodyMarshaller.java
+++ b/sexp/src/main/java/com/novoda/sexp/marshaller/IntegerBodyMarshaller.java
@@ -2,7 +2,7 @@ package com.novoda.sexp.marshaller;
 
 public class IntegerBodyMarshaller implements BodyMarshaller<Integer> {
     @Override
-    public Integer marshall(String input) {
+    public Integer marshal(String input) {
         return Integer.valueOf(input);
     }
 }

--- a/sexp/src/main/java/com/novoda/sexp/marshaller/IntegerWrapperBodyMarshaller.java
+++ b/sexp/src/main/java/com/novoda/sexp/marshaller/IntegerWrapperBodyMarshaller.java
@@ -11,7 +11,7 @@ public class IntegerWrapperBodyMarshaller<T> implements BodyMarshaller<T> {
     }
 
     @Override
-    public T marshall(String input) {
+    public T marshal(String input) {
         try {
             return clazz.getDeclaredConstructor(int.class).newInstance(Integer.parseInt(input));
         } catch (InstantiationException e) {

--- a/sexp/src/main/java/com/novoda/sexp/marshaller/StringBodyMarshaller.java
+++ b/sexp/src/main/java/com/novoda/sexp/marshaller/StringBodyMarshaller.java
@@ -3,7 +3,7 @@ package com.novoda.sexp.marshaller;
 public class StringBodyMarshaller implements BodyMarshaller<String> {
 
     @Override
-    public String marshall(String input) {
+    public String marshal(String input) {
         return input;
     }
 

--- a/sexp/src/main/java/com/novoda/sexp/marshaller/StringWrapperBodyMarshaller.java
+++ b/sexp/src/main/java/com/novoda/sexp/marshaller/StringWrapperBodyMarshaller.java
@@ -11,7 +11,7 @@ public class StringWrapperBodyMarshaller<T> implements BodyMarshaller<T> {
     }
 
     @Override
-    public T marshall(String input) {
+    public T marshal(String input) {
         try {
             return clazz.getDeclaredConstructor(String.class).newInstance(input);
         } catch (InstantiationException e) {

--- a/sexp/src/main/java/com/novoda/sexp/parser/BasicAttributeParser.java
+++ b/sexp/src/main/java/com/novoda/sexp/parser/BasicAttributeParser.java
@@ -26,7 +26,7 @@ public class BasicAttributeParser<T> implements Parser<T>, StartElementListener 
     @Override
     public void start(Attributes attributes) {
         String[] values = getAttributeValues(attributes);
-        listener.onParsed(attributeMarshaller.marshall(values));
+        listener.onParsed(attributeMarshaller.marshal(values));
     }
 
     private String[] getAttributeValues(Attributes attributes) {

--- a/sexp/src/main/java/com/novoda/sexp/parser/BasicParser.java
+++ b/sexp/src/main/java/com/novoda/sexp/parser/BasicParser.java
@@ -18,7 +18,7 @@ public class BasicParser<T> implements Parser<T> {
                 new EndTextElementListener() {
                     @Override
                     public void end(String body) {
-                        listener.onParsed(bodyMarshaller.marshall(body));
+                        listener.onParsed(bodyMarshaller.marshal(body));
                     }
                 }
         );

--- a/sexp/src/test/java/com/novoda/sexp/marshaller/BooleanBodyMarshallerShould.java
+++ b/sexp/src/test/java/com/novoda/sexp/marshaller/BooleanBodyMarshallerShould.java
@@ -15,28 +15,28 @@ public class BooleanBodyMarshallerShould {
     }
 
     @Test
-    public void marshall_string_false_to_boolean_false() throws Exception {
+    public void marshal_string_false_to_boolean_false() throws Exception {
         String rawFalse = "false";
 
-        assertThat(booleanBodyMarshaller.marshall(rawFalse)).isFalse();
+        assertThat(booleanBodyMarshaller.marshal(rawFalse)).isFalse();
     }
 
     @Test
-    public void marshall_string_true_to_boolean_true() throws Exception {
+    public void marshal_string_true_to_boolean_true() throws Exception {
         String rawTrue = "true";
 
-        assertThat(booleanBodyMarshaller.marshall(rawTrue)).isTrue();
+        assertThat(booleanBodyMarshaller.marshal(rawTrue)).isTrue();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void throw_exception_when_input_is_invalid() throws Exception {
         String invalidInput = "invalid";
 
-        booleanBodyMarshaller.marshall(invalidInput);
+        booleanBodyMarshaller.marshal(invalidInput);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void throw_exception_when_input_is_null() throws Exception {
-        booleanBodyMarshaller.marshall(null);
+        booleanBodyMarshaller.marshal(null);
     }
 }

--- a/sexp/src/test/java/com/novoda/sexp/marshaller/IntegerBodyMarshallerShould.java
+++ b/sexp/src/test/java/com/novoda/sexp/marshaller/IntegerBodyMarshallerShould.java
@@ -15,36 +15,36 @@ public class IntegerBodyMarshallerShould {
     }
 
     @Test
-    public void marshall_strings_to_integers() throws Exception {
+    public void marshal_strings_to_integers() throws Exception {
         String validInput = "5";
         int expectedOutput = 5;
 
-        assertThat(integerBodyMarshaller.marshall(validInput)).isEqualTo(expectedOutput);
+        assertThat(integerBodyMarshaller.marshal(validInput)).isEqualTo(expectedOutput);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void throw_exception_when_input_is_invalid() throws Exception {
         String invalidInput = "invalid";
 
-        integerBodyMarshaller.marshall(invalidInput);
+        integerBodyMarshaller.marshal(invalidInput);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void throw_exception_when_input_is_float() throws Exception {
         String invalidInput = "0.5f";
 
-        integerBodyMarshaller.marshall(invalidInput);
+        integerBodyMarshaller.marshal(invalidInput);
     }
 
     @Test(expected = java.lang.NumberFormatException.class)
     public void throw_exception_when_input_is_double() throws Exception {
         String invalidInput = "3.5d";
 
-        integerBodyMarshaller.marshall(invalidInput);
+        integerBodyMarshaller.marshal(invalidInput);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void throw_exception_when_input_is_null() throws Exception {
-        integerBodyMarshaller.marshall(null);
+        integerBodyMarshaller.marshal(null);
     }
 }

--- a/sexp/src/test/java/com/novoda/sexp/marshaller/IntegerWrapperBodyMarshallerShould.java
+++ b/sexp/src/test/java/com/novoda/sexp/marshaller/IntegerWrapperBodyMarshallerShould.java
@@ -7,10 +7,10 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class IntegerWrapperBodyMarshallerShould {
 
     @Test
-    public void marshallStringInput() throws Exception {
+    public void marshalStringInput() throws Exception {
         IntegerWrapperBodyMarshaller<IntegerWrapperClass> cut = integerWrapperBodyMarshaller(IntegerWrapperClass.class);
 
-        IntegerWrapperClass output = cut.marshall("1");
+        IntegerWrapperClass output = cut.marshal("1");
 
         assertThat(output).isEqualTo(new IntegerWrapperClass(1));
     }
@@ -19,21 +19,21 @@ public class IntegerWrapperBodyMarshallerShould {
     public void onlyWorkForClassesWithAnIntegerConstructorArg() throws Exception {
         IntegerWrapperBodyMarshaller<StringWrapperClass> cut = integerWrapperBodyMarshaller(StringWrapperClass.class);
 
-        cut.marshall("");
+        cut.marshal("");
     }
 
     @Test(expected = RuntimeException.class)
     public void onlyWorkForClassesWithASingleConstructorArg() throws Exception {
         IntegerWrapperBodyMarshaller<TwoArgWrapperClass> cut = integerWrapperBodyMarshaller(TwoArgWrapperClass.class);
 
-        cut.marshall("");
+        cut.marshal("");
     }
 
     @Test(expected = RuntimeException.class)
     public void failForClassesWithNoArgConstructor() throws Exception {
         IntegerWrapperBodyMarshaller<NoArgWrapperClass> cut = integerWrapperBodyMarshaller(NoArgWrapperClass.class);
 
-        cut.marshall("");
+        cut.marshal("");
     }
 
     @Test(expected = RuntimeException.class)
@@ -42,7 +42,7 @@ public class IntegerWrapperBodyMarshallerShould {
                 PrivateConstructorWrapperClass.class
         );
 
-        cut.marshall("1");
+        cut.marshal("1");
     }
 
     private <T> IntegerWrapperBodyMarshaller<T> integerWrapperBodyMarshaller(Class<T> clazz) {

--- a/sexp/src/test/java/com/novoda/sexp/marshaller/StringBodyMarshallerShould.java
+++ b/sexp/src/test/java/com/novoda/sexp/marshaller/StringBodyMarshallerShould.java
@@ -15,15 +15,15 @@ public class StringBodyMarshallerShould {
     }
 
     @Test
-    public void marshallTheString() throws Exception {
+    public void marshalTheString() throws Exception {
         String theInput = "theInput";
 
-        assertThat(stringBodyMarshaller.marshall(theInput)).isEqualTo(theInput);
+        assertThat(stringBodyMarshaller.marshal(theInput)).isEqualTo(theInput);
     }
 
     @Test
-    public void marshallNull() throws Exception {
-        assertThat(stringBodyMarshaller.marshall(null)).isEqualTo(null);
+    public void marshalNull() throws Exception {
+        assertThat(stringBodyMarshaller.marshal(null)).isEqualTo(null);
     }
 
 }

--- a/sexp/src/test/java/com/novoda/sexp/marshaller/StringWrapperBodyMarshallerShould.java
+++ b/sexp/src/test/java/com/novoda/sexp/marshaller/StringWrapperBodyMarshallerShould.java
@@ -7,11 +7,11 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class StringWrapperBodyMarshallerShould {
 
     @Test
-    public void marshallStringInput() throws Exception {
+    public void marshalStringInput() throws Exception {
         StringWrapperBodyMarshaller<StringWrapperClass> cut = stringWrapperBodyMarshaller(StringWrapperClass.class);
 
         String testInput = "testInput";
-        StringWrapperClass output = cut.marshall(testInput);
+        StringWrapperClass output = cut.marshal(testInput);
 
         assertThat(output).isEqualTo(new StringWrapperClass(testInput));
     }
@@ -20,14 +20,14 @@ public class StringWrapperBodyMarshallerShould {
     public void onlyWorkForClassesWithASingleStringConstructorArg() throws Exception {
         StringWrapperBodyMarshaller<IntegerWrapperClass> cut = stringWrapperBodyMarshaller(IntegerWrapperClass.class);
 
-        cut.marshall("");
+        cut.marshal("");
     }
 
     @Test(expected = RuntimeException.class)
     public void onlyWorkForClassesWithASingleConstructorArg() throws Exception {
         StringWrapperBodyMarshaller<TwoArgWrapperClass> cut = stringWrapperBodyMarshaller(TwoArgWrapperClass.class);
 
-        cut.marshall("");
+        cut.marshal("");
     }
 
     private <T> StringWrapperBodyMarshaller<T> stringWrapperBodyMarshaller(Class<T> clazz) {

--- a/sexp/src/test/java/com/novoda/sexp/parser/BasicAttributeParserShould.java
+++ b/sexp/src/test/java/com/novoda/sexp/parser/BasicAttributeParserShould.java
@@ -43,7 +43,7 @@ public class BasicAttributeParserShould {
         Attributes attributes = mock(Attributes.class);
         stub(attributes.getValue(ATTR_TAG)).toReturn(FOUND_ATTRIBUTE);
         Object outputObject = new Object();
-        stub(mockMarshaller.marshall(FOUND_ATTRIBUTE)).toReturn(outputObject);
+        stub(mockMarshaller.marshal(FOUND_ATTRIBUTE)).toReturn(outputObject);
         cut.start(attributes);
 
         verify(mockParseWatcher).onParsed(outputObject);
@@ -57,7 +57,7 @@ public class BasicAttributeParserShould {
         stub(attributes.getValue(ATTR_TAG)).toReturn(FOUND_ATTRIBUTE);
         cut.start(attributes);
 
-        verify(mockMarshaller).marshall(FOUND_ATTRIBUTE);
+        verify(mockMarshaller).marshal(FOUND_ATTRIBUTE);
     }
 }
 

--- a/sexp/src/test/java/com/novoda/sexp/parser/BasicParserShould.java
+++ b/sexp/src/test/java/com/novoda/sexp/parser/BasicParserShould.java
@@ -50,6 +50,6 @@ public class BasicParserShould {
 
         mockParse(basicParser, mockListener);
 
-        verify(mockMarshaller).marshall(any(String.class));
+        verify(mockMarshaller).marshal(any(String.class));
     }
 }


### PR DESCRIPTION
#### Problem
This library spells `marshall` with two Ls, when the correct spelling is `marshal`.

#### Solution
Renamed all instances of `marshall` to `marshal`.

##### Test(s) added 
No tests added, just a simple find and replace job. All existing tests pass, the demo app compiles too.

###### Paired with 
`find`,  `sed` and `grep`